### PR TITLE
Fix missing closing single quote

### DIFF
--- a/Generator/Form.php
+++ b/Generator/Form.php
@@ -110,7 +110,7 @@ class Form extends PHPClassFile {
         'doxygen_first' => 'Form constructor.',
         'declaration' => 'public function buildForm(array $form, FormStateInterface $form_state)',
         'body' => array(
-          "£form['element] = array(",
+          "£form['element'] = array(",
           "  '#type' => 'textfield',",
           "  '#title' => t('Enter a value'),",
           "  '#required' => TRUE,",

--- a/Generator/Form7.php
+++ b/Generator/Form7.php
@@ -63,7 +63,7 @@ class Form7 extends BaseGenerator {
         'doxygen_first' => 'Form builder.',
         'declaration' => "function $form_builder(£form, &£form_state)",
         'body' => array(
-          "£form['element] = array(",
+          "£form['element'] = array(",
           "  '#type' => 'textfield',",
           "  '#title' => t('Enter a value'),",
           "  '#required' => TRUE,",


### PR DESCRIPTION
When you have selected an Admin Settings form in module_builder,
this causes an error on attempting to enable the new module.