### PR TITLE
Prevent exceptions thrown during analysis from breaking the task collection

### DIFF
--- a/Task/Collect/PluginTypesCollector.php
+++ b/Task/Collect/PluginTypesCollector.php
@@ -3,6 +3,7 @@
 namespace DrupalCodeBuilder\Task\Collect;
 
 use DrupalCodeBuilder\Environment\EnvironmentInterface;
+use Exception;
 
 /**
  * Task helper for collecting data on plugin types.
@@ -598,7 +599,12 @@ class PluginTypesCollector extends CollectorBase  {
     $potential_base_classes = [];
 
     $service = \Drupal::service($data['service_id']);
-    $definitions = $service->getDefinitions();
+    try {
+      $definitions = $service->getDefinitions();
+    }    
+    catch (Exception $e) {
+      return FALSE;
+    }
 
     // Keep track of the classes we've seen, so we can skip derivative plugins
     // that have the same class.


### PR DESCRIPTION
drupal-code-builder/Task/Collect/PluginTypesCollector::analysePluginTypeBaseClass() relies on getDefinitions() for the plugin manager being analyzed, which may throw an exception in this case:

- Default drupal 8.8.2-dev install
- Enable module_builder, migrate, migrate_drupal
- Edit settings.php, add a new database connection, use 'migrate' key for it. Set connection info that does not resolve properly (either wrong credentials, invalid host, etc).

Given that this breaks the code analysis, I think it's better to handle the exception in a silent way.

A quick test of the suggested fix showed the same number of identified components, compared to a manual fix (removing the 'migrate' db connection before code analysis).