### PR TITLE
Fix fatals on MB 3.21: incompatible signature, null instead of []

### DIFF
--- a/Definition/PropertyDefinition.php
+++ b/Definition/PropertyDefinition.php
@@ -70,7 +70,7 @@ class PropertyDefinition extends BasePropertyDefinition implements \ArrayAccess 
     return $this;
   }
 
-  public function getDeltaDefinition(): self {
+  public function getDeltaDefinition(): BasePropertyDefinition {
     $delta_definition = parent::getDeltaDefinition();
 
     // Remove presets.

--- a/Generator/Render/ClassAnnotation.php
+++ b/Generator/Render/ClassAnnotation.php
@@ -174,7 +174,7 @@ class ClassAnnotation {
         $declaration_line .= '{';
         $docblock_lines[] = $declaration_line;
 
-        $this->renderArray($docblock_lines, $value, $nesting + 1, $annotation_nesting + 1);
+        $this->renderArray($docblock_lines, $value ?? [], $nesting + 1, $annotation_nesting + 1);
 
         $docblock_lines[] = $indent . "},";
       }


### PR DESCRIPTION
Fixes

`
Fatal error: Declaration of DrupalCodeBuilder\Definition\PropertyDefinition::getDeltaDefinition(): DrupalCodeBuilder\Definition\PropertyDefinition must be compatible with MutableTypedData\Definition\DataDefinition::getDeltaDefinition(): MutableTypedData\Definition\DataDefinition in /path/to/vendor/drupal-code-builder/drupal-code-builder/Definition/PropertyDefinition.php on line 16
`

And

`
TypeError: Argument 2 passed to DrupalCodeBuilder\Generator\Render\ClassAnnotation::renderArray() must be of the type array, null given, called in /path/to/vendor/drupal-code-builder/drupal-code-builder/Generator/Render/ClassAnnotation.php on line 177 in DrupalCodeBuilder\Generator\Render\ClassAnnotation->renderArray() (line 136 of /path/to/vendor/drupal-code-builder/drupal-code-builder/Generator/Render/ClassAnnotation.php).
`

Running MB on Drupal 9.2.6, PHP 7.3.28. Found these errors while trying to generate a condition plugin, injecting service datetime.time and pseudo-service storage:node.